### PR TITLE
Update C++ standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if( NOT PROJECT_NAME )
 endif()
 
 if( NOT CMAKE_CXX_STANDARD )
-	set( CMAKE_CXX_STANDARD 14 )
+	set( CMAKE_CXX_STANDARD 20 )
 endif()
   
 #if( MSVC ) # link runtime statically with MSVC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 # CMake
 
-cmake_minimum_required( VERSION 3.11 )
+cmake_minimum_required( VERSION 3.12 )
 set_property( GLOBAL PROPERTY USE_FOLDERS ON )
 cmake_policy(SET CMP0091 NEW)
 
@@ -15,6 +15,9 @@ endif()
 
 if( NOT CMAKE_CXX_STANDARD )
 	set( CMAKE_CXX_STANDARD 20 )
+endif()
+if( NOT CMAKE_CUDA_STANDARD )
+	set( CMAKE_CUDA_STANDARD 20 )
 endif()
   
 #if( MSVC ) # link runtime statically with MSVC


### PR DESCRIPTION
update the c++ standard to 20 for both the c++ and cuda compiles, fixes the cuda 11.3 compile errors on windows. Require cmake 3.12 now as that is min version for c++ 20.